### PR TITLE
fix: properly implement destroy() to prevent vEvents TypeError on re-render

### DIFF
--- a/ng-gantt/src/gantt/gantt.component.spec.ts
+++ b/ng-gantt/src/gantt/gantt.component.spec.ts
@@ -1,19 +1,34 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import * as JSGantt from 'jsgantt-improved';
 
 import { GanttEditorComponent } from './gantt.component';
 
-describe('GantteditorComponent', () => {
+describe('GanttEditorComponent', () => {
   let component: GanttEditorComponent;
   let fixture: ComponentFixture<GanttEditorComponent>;
+  let mockEditorInstance: any;
 
-  beforeEach(async(() => {
+  function buildMockEditor(overrides: any = {}): any {
+    return {
+      getDivId: jasmine.createSpy('getDivId').and.returnValue('mock-div-id'),
+      setOptions: jasmine.createSpy('setOptions'),
+      AddTaskItemObject: jasmine.createSpy('AddTaskItemObject'),
+      Draw: jasmine.createSpy('Draw'),
+      options: {},
+      ...overrides
+    };
+  }
+
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ GanttEditorComponent ]
-    })
-    .compileComponents();
+      declarations: [GanttEditorComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
+    mockEditorInstance = buildMockEditor();
+    spyOn(JSGantt as any, 'GanttChart').and.returnValue(mockEditorInstance);
+
     fixture = TestBed.createComponent(GanttEditorComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -21,5 +36,143 @@ describe('GantteditorComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // destroy()
+  // ---------------------------------------------------------------------------
+
+  describe('destroy()', () => {
+    it('should clear the container innerHTML when an editor exists', () => {
+      const container = component.ganttEditorContainer.nativeElement;
+      container.innerHTML = '<div>stale chart content</div>';
+
+      component.destroy();
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should null out the editor reference when an editor exists', () => {
+      expect(component.getEditor()).not.toBeNull();
+
+      component.destroy();
+
+      expect(component.getEditor()).toBeNull();
+    });
+
+    it('should be a no-op (not throw) when editor is already null', () => {
+      component.destroy(); // first call nulls the editor
+      expect(() => component.destroy()).not.toThrow();
+    });
+
+    it('should not clear the container when editor is null', () => {
+      const container = component.ganttEditorContainer.nativeElement;
+      container.innerHTML = '<div>existing content</div>';
+      component.destroy(); // null the editor
+
+      component.destroy(); // second call — should leave the DOM untouched
+      expect(container.innerHTML).toBe('<div>existing content</div>');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // data setter
+  // ---------------------------------------------------------------------------
+
+  describe('data setter', () => {
+    it('should store the supplied value', () => {
+      const rows = [{ pID: 1, pName: 'Task A' }];
+      component.data = rows;
+      // Access via getEditor flow: the data should have been passed to AddTaskItemObject
+      expect(mockEditorInstance.AddTaskItemObject).toHaveBeenCalled();
+    });
+
+    it('should call destroy() then re-initialise when an editor already exists', () => {
+      const destroySpy = spyOn(component, 'destroy').and.callThrough();
+      const initSpy = spyOn(component, 'ngOnInit').and.callThrough();
+
+      component.data = [{ pID: 2, pName: 'Task B' }];
+
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+      expect(initSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still call ngOnInit when no prior editor exists but container is available', () => {
+      // Reset so there is no editor
+      component.destroy();
+      (JSGantt as any).GanttChart.calls.reset();
+
+      const initSpy = spyOn(component, 'ngOnInit').and.callThrough();
+      component.data = [{ pID: 3, pName: 'Task C' }];
+
+      expect(initSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call ngOnInit when ganttEditorContainer is not yet available', () => {
+      // Simulate the case where the setter fires before the view is initialised
+      (component as any).ganttEditorContainer = undefined;
+      component.destroy(); // clear editor so we test the no-editor branch
+
+      const initSpy = spyOn(component, 'ngOnInit').and.callThrough();
+      component.data = [{ pID: 4, pName: 'Task D' }];
+
+      expect(initSpy).not.toHaveBeenCalled();
+    });
+
+    it('should create a fresh GanttChart instance on each data update', () => {
+      const callsBefore = (JSGantt as any).GanttChart.calls.count();
+      component.data = [{ pID: 5, pName: 'Task E' }];
+      const callsAfter = (JSGantt as any).GanttChart.calls.count();
+
+      expect(callsAfter).toBe(callsBefore + 1);
+    });
+
+    it('should register each data row with AddTaskItemObject', () => {
+      const rows = [
+        { pID: 10, pName: 'Task 1' },
+        { pID: 11, pName: 'Task 2' },
+        { pID: 12, pName: 'Task 3' }
+      ];
+
+      component.data = rows;
+
+      expect(mockEditorInstance.AddTaskItemObject).toHaveBeenCalledTimes(rows.length);
+    });
+
+    it('should set pGantt on each row to the new editor instance', () => {
+      const rows = [{ pID: 20, pName: 'Task X' }];
+      component.data = rows;
+
+      expect(rows[0].pGantt).toBe(component.getEditor());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // destroy() + data setter interaction
+  // ---------------------------------------------------------------------------
+
+  describe('destroy() then data setter interaction', () => {
+    it('should leave the container clean before re-rendering', () => {
+      const container = component.ganttEditorContainer.nativeElement;
+      // Simulate stale content from a previous render
+      container.innerHTML = '<div id="stale">old chart</div>';
+
+      component.data = [{ pID: 30, pName: 'Fresh Task' }];
+
+      // After destroy clears innerHTML and GanttChart re-renders, the stale
+      // content should be gone (GanttChart writes its own output)
+      expect(container.querySelector('#stale')).toBeNull();
+    });
+
+    it('should expose the new editor via getEditor() after re-render', () => {
+      const firstEditor = component.getEditor();
+      const newMock = buildMockEditor();
+      (JSGantt as any).GanttChart.and.returnValue(newMock);
+
+      component.data = [{ pID: 40, pName: 'New Task' }];
+
+      expect(component.getEditor()).toBe(newMock);
+      expect(component.getEditor()).not.toBe(firstEditor);
+    });
   });
 });

--- a/ng-gantt/src/gantt/gantt.component.ts
+++ b/ng-gantt/src/gantt/gantt.component.ts
@@ -28,6 +28,8 @@ export class GanttEditorComponent implements OnInit {
     this._data = value;
     if (this.editor) {
       this.destroy();
+    }
+    if (this.ganttEditorContainer) {
       this.ngOnInit();
     }
   }
@@ -86,7 +88,10 @@ export class GanttEditorComponent implements OnInit {
   }
 
   public destroy() {
-    // this.editor.destroy();
+    if (this.editor) {
+      this.ganttEditorContainer.nativeElement.innerHTML = '';
+      this.editor = null;
+    }
   }
 
   public getEditor(){


### PR DESCRIPTION
## Problem

When the `data` input is updated after initial render, `destroy()` was a no-op (the actual teardown call was commented out). This left the old `GanttChart` instance alive on the DOM with its stale jsgantt-improved event handlers still referencing the now-orphaned chart object.

When a user then opens the task detail editor, the handler walks up to its `pGantt` chart reference, finds `undefined`, and throws:

```
TypeError: Cannot read property 'vEvents' of undefined
```

Reported in #28.

## Fix

`destroy()` now clears the container element's `innerHTML` and nulls `this.editor` before re-initializing:

```ts
public destroy() {
  if (this.editor) {
    this.ganttEditorContainer.nativeElement.innerHTML = '';
    this.editor = null;
  }
}
```

The `data` setter is also tightened: it destroys the old instance (if any), then re-inits whenever the view container is available — covering the edge case where `data` is set before `ngOnInit` runs.

## Testing

1. Render `<ng-gantt [data]="tasks">` with a task list
2. Update the `tasks` binding to a new array (triggering the setter)
3. Click a task's detail link — previously threw `vEvents` TypeError, now works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)